### PR TITLE
Fix when using rpm -ivh on installation

### DIFF
--- a/epm.erl
+++ b/epm.erl
@@ -463,7 +463,11 @@ rpm(#fpm{paths = Dirs0, output = OutPath, force = Force, name = Name0, version =
 
   % Need to sort files because mapFind will make bsearch to find them
   Files = rpm_load_file_list(Dirs),
-  CPIO = zlib:gzip(cpio(Files)),
+  FileSizes = file_sizes (Files),
+  UncompressedCPIO = cpio(Files),
+  UncompressedCPIOSize = iolist_size (UncompressedCPIO),
+  CPIO = zlib:gzip(UncompressedCPIO),
+  CPIOSize = iolist_size(CPIO),
 
   Info1 = [
     {summary, FPM#fpm.description},
@@ -486,7 +490,9 @@ rpm(#fpm{paths = Dirs0, output = OutPath, force = Force, name = Name0, version =
                               {requirename, [X || {X, _, _} <- Deps]},
                               {requireversion, [X || {_, _, X} <- Deps]},
                               {requireflags, [X || {_, X, _} <- Deps]},
-                              {size,        iolist_size(CPIO)}],
+                              {size, FileSizes},
+                              {archivesize, UncompressedCPIOSize}
+                             ],
 
   #fpm{post_install=PostInst,pre_uninstall=PreRm,post_uninstall=PostRm}=FPM,
   #fpm{epoch = Epoch}=FPM,
@@ -529,7 +535,7 @@ rpm(#fpm{paths = Dirs0, output = OutPath, force = Force, name = Name0, version =
 
 
   Signature = [{sha1_header,hex(crypto:hash(sha, [Header]))}] ++ GPGSign++
-    [{signature_size,iolist_size(Header) + iolist_size(CPIO)},
+    [{signature_size,iolist_size(Header) + CPIOSize},
     {md5_header,{bin,MD5}}],
 
 
@@ -590,6 +596,18 @@ rpm_pad(Data, N) ->
   Pad = binary:copy(<<0>>, iolist_size(Data) rem N),
   Pad.
 
+
+file_sizes (Files) ->
+  lists:foldl (fun(Path,A) ->
+                 {ok, #file_info{type = T, size = S}} =
+                    file:read_file_info(Path),
+                 case T of
+                   regular -> A + S;
+                   _ -> A
+                 end
+               end,
+               0,
+               Files).
 
 rpm_load_file_list(Dirs) ->
   Files1 = lists:usort(lists:flatmap(fun(Dir) -> rpm_list(Dir) end, Dirs)),


### PR DESCRIPTION
When I install rpm's I'm in the habit of using 'rpm -ivh file.rpm' but noticed that with rpms created with this tool, I got unexpected output.  Here's an example
```
> mkdir foo && cd foo && mkdir tmp && mkdir -p etc/init.d && echo "stuff" > tmp/foo && echo '#!/bin/sh' > etc/init.d/foo && echo 'echo "hello world"' >> etc/init.d/foo
> ../epm.erl -f -t rpm -n test -v 1.1.0 -a x86_64 tmp etc
> > sudo rpm -ivh test-1.1.0-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:test-1.1.0-1                     #################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################%
```
After looking at the rpm source code and seeing it was size related I looked into how internal sizes were calculated and figured out they were not being done correctly.  I found a good description here http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/pkgformat.html which had

> RPMTAG_SIZE
This tag specifies the sum of the sizes of the regular files in the archive.

> RPMTAG_ARCHIVESIZE
This tag specifies the uncompressed size of the Payload archive, including the cpio headers.

Once I switched to these for the sizes, I got the expected output
```
> sudo rpm -ivh test-1.1.0-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:test-1.1.0-1                     ################################# [100%]
```
I figure others might have similar issues.